### PR TITLE
Explicitly use Python3.8 for consistency on fresh EC2 instance

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 yum -y update
 yum install -y aws-cli
+yum install -y amazon-linux-extras
 amazon-linux-extras install python3.8
+ln -sf $(which python3.8) /usr/bin/python3
 cd /home/ec2-user || return
 if [[ ! -f ./install ]]; then
   wget https://aws-codedeploy-us-east-2.s3.us-east-2.amazonaws.com/latest/install

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ source scripts/vercomp.sh
 
 cd app/ 2>/dev/null || true
 
-version=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
+version=$(python3 -V 2>&1 | grep -Po '(?<=Python )(.+)')
 if [[ -z "$version" ]]
 then
     echo "No Python detected" 
@@ -26,7 +26,7 @@ fi
 
 echo "Creating virtual environment in: $(pwd)"
 python3 -m pip install --user virtualenv
-virtualenv venv --python=python3
+python3 -m virtualenv venv --python=python3
 source venv/bin/activate
 pip install -r requirements.txt
 echo "If running locally, try: sudo -E venv/bin/python3 src/main.py recipes log.txt"


### PR DESCRIPTION
Fixing some things so that a fresh EC2 instance can run the app without manual configuration.