### PR TITLE
Add script that must be manually executed after EC2 image creation

### DIFF
--- a/scripts/install_codedeploy.sh
+++ b/scripts/install_codedeploy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Must run on EC2 instance before code deploy agent
+# grabs new versions of code. This should be automated, 
+# but isn't right now.
+
+sudo yum -y update
+sudo yum -y install ruby
+sudo yum -y install wget
+
+cd /home/ec2-user
+
+wget https:/aws-codedeploy-us-east-2.s3.us-east-2.amazonaws.com/latest/install
+chmod +x ./install
+sudo ./install auto
+sudo service codedeploy-agent status


### PR DESCRIPTION
This should automatically fire off when an EC2 image is created, but for now I must manually execute it on the fresh image. I could also make an AMI that just has this pre-installed.